### PR TITLE
When calculating the ratio, 0/0 should be 100%, not 0%.

### DIFF
--- a/src/main/java/hudson/plugins/codecover/Ratio.java
+++ b/src/main/java/hudson/plugins/codecover/Ratio.java
@@ -63,7 +63,7 @@ final public class Ratio implements Serializable {
      */
     @Exported
     public float getPercentageFloat() {
-        return denominator<=0? 0: 100*numerator/denominator;
+        return denominator<=0? 100: 100*numerator/denominator;
     }
 
     public boolean equals(Object o) {


### PR DESCRIPTION
This is especially important when Jenkins is listing the project's issues, where a lack of loops, for example, will be listed as an issue because of the 0% coverage.
